### PR TITLE
Improve test coverage and update for Erlang 18

### DIFF
--- a/src/gen_batch_app.erl
+++ b/src/gen_batch_app.erl
@@ -4,8 +4,7 @@
 -export([start/2,stop/1]).
 
 start(_Type, _StartArgs) ->
-    supervisor:start_link({local, gen_batch_sup}, gen_batch_sup, []).
+  supervisor:start_link({local, gen_batch_sup}, gen_batch_sup, []).
 
 stop(_State) ->
-    ok.
-
+  ok.

--- a/test/batch_shutdown_sup.erl
+++ b/test/batch_shutdown_sup.erl
@@ -1,0 +1,20 @@
+-module(batch_shutdown_sup).
+
+-behaviour(gen_batch).
+-export([init/1, process_item/3, worker_died/5, job_stopping/1, job_complete/2]).
+
+init([]) ->
+  {ok, 1, [1], []}.
+
+process_item(_Item, _StartTime, []) ->
+  exit(self(), shutdown),
+  ok.
+
+worker_died(_, _WorkerPid, _StartTime, _Info, []) ->
+  ok.
+
+job_stopping([]) ->
+  ok.
+
+job_complete(_Status, []) ->
+  ok.

--- a/test/gen_batch_app_tests.erl
+++ b/test/gen_batch_app_tests.erl
@@ -1,0 +1,23 @@
+-module(gen_batch_app_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+start_test_() ->
+  {setup,
+  fun() ->
+    {ok, Pid} = gen_batch_app:start(ignored_type, ignored_start_args),
+    Pid
+  end,
+  fun(Pid) ->
+    exit(Pid, normal),
+    timer:sleep(100),
+    false = is_process_alive(Pid),
+    ok
+  end,
+  fun(Pid) ->
+    {"starts the application",
+    ?_assert(is_process_alive(Pid))}
+  end}.
+
+stop_test_() ->
+  {"returns ok",
+  ?_assertEqual(ok, gen_batch_app:stop(ignored_state))}.

--- a/test/gen_batch_runner_tests.erl
+++ b/test/gen_batch_runner_tests.erl
@@ -2,45 +2,71 @@
 -include_lib("eunit/include/eunit.hrl").
 
 job_runner_test_() ->
-    {setup,
-     fun() -> error_logger:tty(false), gen_batch_sup:start_link() end,
-     fun({ok, Pid}) -> exit(Pid, normal) end,
-     [
-      {"Normal jobs shoul complete successfully",
-       ?_assertMatch(ok, gen_batch:sync_run_job(batch_normal, []))},
+  {setup,
+  fun() ->
+    error_logger:tty(false),
+    gen_batch_sup:start_link()
+  end,
+  fun({ok, Pid}) ->
+    exit(Pid, normal)
+  end,
+  [
+  {"Normal jobs should complete successfully",
+  ?_assertEqual(ok, gen_batch:sync_run_job(batch_normal, []))},
+  {"Exceptions thrown from callback modules shouldn't crash the job",
+  ?_assertEqual(ok, gen_batch:sync_run_job(batch_throw, []))},
+  {"Errors in callback modules shouldn't crash the job",
+  ?_assertEqual(ok, gen_batch:sync_run_job(batch_crash, []))},
+  {"Errors in callback module init should be returned to the caller",
+  ?_assertEqual({error, testing}, gen_batch:sync_run_job(batch_init_fail, []))},
+  {"The runner should stop when a worker asks",
+  ?_assertEqual(ok, gen_batch:sync_run_job(batch_worker_stop, []))},
+  {"The runner should stop when caller asks",
+  ?_test(begin
+    {ok, Pid} = supervisor:start_child(gen_batch_runner_sup, [batch_wait]),
+    gen_batch_runner:run_job(Pid, []),
+    ?assert(is_process_alive(Pid)),
+    gen_batch_runner:stop(Pid),
+    timer:sleep(100), % time to wind down
+    ?assertNot(is_process_alive(Pid))
+  end
+  )},
+  {"The runner should continue when worker supervisor dies",
+  ?_assertEqual(ok, gen_batch:sync_run_job(batch_kill_sup, []))},
+  {"The workers should be able to return results that are aggregated and replied back on synchronous calls",
+  ?_test(begin
+    {results, Results} = gen_batch:sync_run_job(batch_worker_results, []),
+    ?_assertEqual([1, 2, 3], lists:sort(Results))
+   end
+  )},
+  {"The worker should stop when the worker is shut down",
+  ?_test(begin
+    {ok, Pid} = supervisor:start_child(gen_batch_runner_sup, [batch_shutdown_sup]),
+    gen_batch_runner:run_job(Pid, []),
+    SupPid = whereis(gen_batch_runner_sup),
+    ?assert(is_process_alive(Pid)),
+    ?assert(is_process_alive(SupPid)),
+    timer:sleep(100), % time to wind down
+    ?assertNot(is_process_alive(Pid))
+  end)}]
+}.
 
-      {"Exceptions thrown from callback modules shouldn't crash the job",
-       ?_assertMatch(ok, gen_batch:sync_run_job(batch_throw, []))},
+handle_info_test_() ->
+  {"ignores unknown events",
+  ?_assertEqual({next_state, fake_state_name, fake_state},
+    gen_batch_runner:handle_info(unknown_event, fake_state_name, fake_state))}.
 
-      {"Errors in callback modules shouldn't crash the job",
-       ?_assertMatch(ok, gen_batch:sync_run_job(batch_crash, []))},
+handle_event_test_() ->
+  {"stops when receiving unknown events",
+  ?_assertEqual({stop, unsupportedOperation, fake_state},
+    gen_batch_runner:handle_event(unknown_event, fake_state_name, fake_state))}.
 
-      {"Errors in callback module init should be returned to the caller",
-       ?_assertMatch({error, testing}, gen_batch:sync_run_job(batch_init_fail, []))},
+handle_sync_event_test_() ->
+  {"stops when receiving unknown events",
+  ?_assertEqual({stop, unsupportedOperation, fake_state},
+    gen_batch_runner:handle_sync_event(unknown_event, self(), fake_state_name, fake_state))}.
 
-      {"The runner should stop when a worker asks",
-       ?_assertMatch(ok, gen_batch:sync_run_job(batch_worker_stop, []))},
-
-      {"The runner should stop when caller asks",
-       ?_test(
-            begin
-                {ok, Pid} = supervisor:start_child(gen_batch_runner_sup, [batch_wait]),
-                gen_batch_runner:run_job(Pid, []),
-                ?assert(is_process_alive(Pid)),
-                gen_batch_runner:stop(Pid),
-                timer:sleep(100), % time to wind down
-                ?assertNot(is_process_alive(Pid))
-            end
-       )},
-
-      {"The runner should continue when worker supervisor dies",
-       ?_assertMatch(ok, gen_batch:sync_run_job(batch_kill_sup, []))},
-
-       {"The workers should be able to return results that are aggregated and replied back on synchronous calls",
-         ?_test(
-           begin
-             {results, Results} = gen_batch:sync_run_job(batch_worker_results, []),
-             ?_assertMatch([1, 2, 3], lists:sort(Results))
-           end
-         )}
-     ]}.
+code_change_test_() ->
+  {"returns ok",
+  ?_assertEqual({ok, fake_state_name, fake_state},
+    gen_batch_runner:code_change(ignored_version, fake_state_name, fake_state, ignored_extra))}.

--- a/test/gen_batch_tests.erl
+++ b/test/gen_batch_tests.erl
@@ -1,0 +1,29 @@
+-module(gen_batch_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+run_job_test_() ->
+  {inorder,
+    {foreach,
+    local,
+    fun() ->
+      error_logger:tty(false),
+      gen_batch_sup:start_link()
+    end,
+    fun({ok, Pid}) ->
+      true = exit(Pid, normal),
+      timer:sleep(100)
+    end,
+    [{"returns results from a sync job",
+    ?_test(begin
+      {results, Results} = gen_batch:sync_run_job(batch_worker_results, []),
+      Sorted = lists:sort(Results),
+      Expected = [1, 2, 3],
+      ?assertEqual(Expected, Sorted)
+    end)},
+    {"returns `ok` immediately from an async job",
+    ?_test(begin
+      Result = gen_batch:run_job(batch_worker_results, []),
+      ?assertEqual(ok, Result)
+    end)}]}
+  }.

--- a/test/gen_batch_worker_tests.erl
+++ b/test/gen_batch_worker_tests.erl
@@ -1,0 +1,15 @@
+-module(gen_batch_worker_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+stop_test_() ->
+  {"returns ok if the process is already dead",
+  ?_assertEqual(ok, gen_batch_worker:stop(c:pid(0, 42, 42)))}.
+
+handle_info_test_() ->
+  {"returns `noreply`",
+  ?_assertEqual({noreply, fake_state}, gen_batch_worker:handle_info(ignored_info, fake_state))}.
+
+code_change_test_() ->
+  {"returns ok",
+  ?_assertEqual({ok, fake_state}, gen_batch_worker:code_change(ignored_version, fake_state, ignored_extra))}.


### PR DESCRIPTION
This pull request aims to complete code coverage for the `gen_batch` source on an *application* level, which is to see that each module's coverage is not independent and relies on being covered by code paths in other modules.

This pull request also makes the minor change of changing the deprecated `erlang:now/0` to `os:timestamp/0` for Erlang 18.x usage.