### PR TITLE
Comment out warnings_as_errors directive

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,8 @@
              warn_unused_import,
              warn_shadow_vars,
              warn_export_vars,
-             warnings_as_errors,
+             % To compile this in erlang 21, this needs to be turned off so deprecation warnings don't halt the build
+             %% ,
              warn_export_all ]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
In order for gen_batch to compile, the warnings_as_errors directive needs to be commented out. `gen_fsm` has been deprecated in favor of `gen_statem` and the compiler lets you know it. This directive can be uncommented when the `gen_fsm` to `gen_statem` conversion happens.